### PR TITLE
Append correct path

### DIFF
--- a/src/main/java/filemanager/FileManager.java
+++ b/src/main/java/filemanager/FileManager.java
@@ -50,12 +50,6 @@ public class FileManager {
                             throw new FileNotFoundException("Players folder missing info.txt");
                         File playerInfo = listOfFiles[0];
                         Player newPlayer = Parser.readPlayerInfo(playerInfo.getPath());
-//                        newPlayer.setFullLunchCommand(
-//                                playersFolder.getAbsolutePath() + "\\"
-//                                        + newPlayer.getIndexNumber() + "\\"
-//                                        + newPlayer.getLunchCommand()
-//                        );
-                        //newPlayer.setFullLunchCommand(newPlayer.getLunchCommand());
 
                         players.add(newPlayer);
                     } catch (FileNotFoundException e) {

--- a/src/main/java/filemanager/FileManager.java
+++ b/src/main/java/filemanager/FileManager.java
@@ -55,7 +55,7 @@ public class FileManager {
 //                                        + newPlayer.getIndexNumber() + "\\"
 //                                        + newPlayer.getLunchCommand()
 //                        );
-                        newPlayer.setFullLunchCommand(newPlayer.getLunchCommand());
+                        //newPlayer.setFullLunchCommand(newPlayer.getLunchCommand());
 
                         players.add(newPlayer);
                     } catch (FileNotFoundException e) {

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -1,6 +1,8 @@
 package parser;
 
 import mainlogic.Player;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -14,7 +16,9 @@ public class Parser {
         Scanner input = new Scanner(new FileReader(fileName));
         String indexNumber, alias, name, surname, lunchCommand;
 
-        indexNumber = new File( new File(fileName).getParent() ).getName(); //Get name of parent of info.txt file
+        File playerFolder = new File(fileName).getParentFile();
+        System.out.println(playerFolder.getAbsolutePath());
+        indexNumber = playerFolder.getName(); //Get name of parent of info.txt file
 
         try {
             if (input.hasNext())
@@ -40,6 +44,10 @@ public class Parser {
                 lunchCommand = input.nextLine();
                 if (lunchCommand.length() <= 0) throw new ParseException("No lunch command", 3);
             } else throw new ParseException("No lunch command", 3);
+
+            //TODO: Set full lunch command
+
+
         } catch (ParseException e) {
             input.close(); //Close input and rethrow exception
             throw e;
@@ -47,5 +55,15 @@ public class Parser {
 
         input.close();
         return new Player(indexNumber, alias, name, surname, lunchCommand);
+    }
+
+    @Contract(pure = true)
+    public static boolean isJavaProgram(@NotNull String lunchCommand) {
+        return lunchCommand.matches("java -jar .*.jar");
+    }
+
+    @Contract(pure = true)
+    public static boolean isExeProgram(@NotNull String lunchCommand) {
+        return lunchCommand.matches(".*.exe");
     }
 }

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -9,12 +9,14 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.text.ParseException;
 import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Parser {
     public static Player readPlayerInfo(String fileName) throws FileNotFoundException, ParseException {
 
         Scanner input = new Scanner(new FileReader(fileName));
-        String indexNumber, alias, name, surname, lunchCommand;
+        String indexNumber, alias, name, surname, lunchCommand, fullLunchCommand;
 
         File playerFolder = new File(fileName).getParentFile();
         System.out.println(playerFolder.getAbsolutePath());
@@ -45,8 +47,7 @@ public class Parser {
                 if (lunchCommand.length() <= 0) throw new ParseException("No lunch command", 3);
             } else throw new ParseException("No lunch command", 3);
 
-            //TODO: Set full lunch command
-
+            fullLunchCommand = generateFullLunchCommand(playerFolder, lunchCommand);
 
         } catch (ParseException e) {
             input.close(); //Close input and rethrow exception
@@ -54,7 +55,27 @@ public class Parser {
         }
 
         input.close();
-        return new Player(indexNumber, alias, name, surname, lunchCommand);
+        return new Player(indexNumber, alias, name, surname, lunchCommand, fullLunchCommand);
+    }
+
+    private static String generateFullLunchCommand(File parentFolder, String lunchCommand) {
+        String parenFolderPath = parentFolder.getAbsolutePath();
+
+        if (isJavaProgram(lunchCommand)) {
+            Pattern pattern = Pattern.compile("(\\b\\w*\\.jar)");
+            Matcher matcher = pattern.matcher(lunchCommand);
+            matcher.find();
+
+            String programName = matcher.group();
+
+            return "java -jar " + parenFolderPath + "\\" + programName;
+        }
+        else if (isExeProgram(lunchCommand)) {
+            return parentFolder.getAbsolutePath() + "\\" + lunchCommand;
+        }
+        else { //Type unrecognized. Better not touch
+            return lunchCommand;
+        }
     }
 
     @Contract(pure = true)

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -59,6 +59,9 @@ public class Parser {
     }
 
     private static String generateFullLunchCommand(File parentFolder, String lunchCommand) {
+        if (lunchCommand.contains("\\")) //It's already a path
+            return lunchCommand;
+
         String parenFolderPath = parentFolder.getAbsolutePath();
 
         if (isJavaProgram(lunchCommand)) {

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -71,10 +71,10 @@ public class Parser {
 
             String programName = matcher.group();
 
-            return "java -jar " + parenFolderPath + "\\" + programName;
+            return "java -jar \"" + parenFolderPath + "\\" + programName + "\"";
         }
         else if (isExeProgram(lunchCommand)) {
-            return parentFolder.getAbsolutePath() + "\\" + lunchCommand;
+            return "\"" + parentFolder.getAbsolutePath() + "\\" + lunchCommand + "\"";
         }
         else { //Type unrecognized. Better not touch
             return lunchCommand;

--- a/src/test/java/parser/ParserTest.java
+++ b/src/test/java/parser/ParserTest.java
@@ -119,7 +119,7 @@ public class ParserTest {
             fail();
         }
 
-        if (!player.getFullLunchCommand().matches("[A-Z]:\\.*\\\d{6}\\.*.exe"))
+        if (!player.getFullLunchCommand().matches("[A-Z]:\\\\.*\\\\\\d{6}\\\\.*.exe"))
             fail();
     }
 

--- a/src/test/java/parser/ParserTest.java
+++ b/src/test/java/parser/ParserTest.java
@@ -100,7 +100,54 @@ public class ParserTest {
 
     @Test
     public void appendExePath() {
+        try {
+            PrintWriter writer = new PrintWriter(temFileName, "UTF-8");
+            writer.println("Kserkses");
+            writer.println("Aleksander Dobrowolski");
+            writer.println("gamer.exe");
+            writer.close();
+        } catch (FileNotFoundException | UnsupportedEncodingException exception) {
+            fail();
+        }
 
+        Player player = null;
+
+        try {
+            player = Parser.readPlayerInfo(temFileName);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        if (!player.getFullLunchCommand().matches("[A-Z]:\\.*\\\d{6}\\.*.exe"))
+            fail();
+    }
+
+    @Test
+    public void edePathAlreadyProvided() {
+        String initialPath = "F:\\folder1\\folder22\\gamer.exe";
+
+        try {
+            PrintWriter writer = new PrintWriter(temFileName, "UTF-8");
+            writer.println("Kserkses");
+            writer.println("Aleksander Dobrowolski");
+            writer.println(initialPath);
+            writer.close();
+        } catch (FileNotFoundException | UnsupportedEncodingException exception) {
+            fail();
+        }
+
+        Player player = null;
+
+        try {
+            player = Parser.readPlayerInfo(temFileName);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        if (!player.getFullLunchCommand().equals(initialPath))
+            fail();
     }
 
     @After

--- a/src/test/java/parser/ParserTest.java
+++ b/src/test/java/parser/ParserTest.java
@@ -67,8 +67,34 @@ public class ParserTest {
             fail();
         }
 
-        System.out.println(FileManager.getProgramLocation());
         if (!player.getFullLunchCommand().matches("java -jar [A-Z]:\\\\.*\\\\\\d{6}\\\\.*.jar"))
+            fail();
+    }
+
+    @Test
+    public void javaPathAlreadyProvided() throws IOException {
+        String initialCommand = "java -jar D:\\folder\\proGram.jar";
+
+        try {
+            PrintWriter writer = new PrintWriter(temFileName, "UTF-8");
+            writer.println("Kserkses");
+            writer.println("Aleksander Dobrowolski");
+            writer.println(initialCommand);
+            writer.close();
+        } catch (FileNotFoundException | UnsupportedEncodingException exception) {
+            fail();
+        }
+
+        Player player = null;
+
+        try {
+            player = Parser.readPlayerInfo(temFileName);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        if (!player.getFullLunchCommand().equals(initialCommand)) //Path shouldn't be changed
             fail();
     }
 

--- a/src/test/java/parser/ParserTest.java
+++ b/src/test/java/parser/ParserTest.java
@@ -1,14 +1,12 @@
 package parser;
 
+import filemanager.FileManager;
 import mainlogic.Player;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 
 import static org.junit.Assert.fail;
 
@@ -21,7 +19,10 @@ public class ParserTest {
     public void setUp() /*throws Exception*/ {
         new File(tempFolderName).mkdir();
         new File(tempPlayerFolderName).mkdir();
+    }
 
+    @Test
+    public void readPlayerInfo() {
         try {
             PrintWriter writer = new PrintWriter(temFileName, "UTF-8");
             writer.println("Kserkses");
@@ -31,10 +32,7 @@ public class ParserTest {
         } catch (FileNotFoundException | UnsupportedEncodingException exception) {
             fail();
         }
-    }
 
-    @Test
-    public void readPlayerInfo() {
         Player player = null;
 
         try {
@@ -46,6 +44,37 @@ public class ParserTest {
         //if (player == null) fail();
 
         if (!player.toString().equals("Kserkses Aleksander Dobrowolski fajny_program.exe")) fail();
+    }
+
+    @Test
+    public void appendJavaPath() throws IOException {
+        try {
+            PrintWriter writer = new PrintWriter(temFileName, "UTF-8");
+            writer.println("Kserkses");
+            writer.println("Aleksander Dobrowolski");
+            writer.println("java -jar proGram.jar");
+            writer.close();
+        } catch (FileNotFoundException | UnsupportedEncodingException exception) {
+            fail();
+        }
+
+        Player player = null;
+
+        try {
+            player = Parser.readPlayerInfo(temFileName);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+
+        System.out.println(FileManager.getProgramLocation());
+        if (!player.getFullLunchCommand().matches("java -jar [A-Z]:\\\\.*\\\\\\d{6}\\\\.*.jar"))
+            fail();
+    }
+
+    @Test
+    public void appendExePath() {
+
     }
 
     @After

--- a/src/test/java/parser/ParserTest.java
+++ b/src/test/java/parser/ParserTest.java
@@ -19,6 +19,13 @@ public class ParserTest {
     public void setUp() /*throws Exception*/ {
         new File(tempFolderName).mkdir();
         new File(tempPlayerFolderName).mkdir();
+        try {
+            new File(temFileName).createNewFile();
+        }
+        catch (IOException e) {
+            fail();
+        }
+
     }
 
     @Test
@@ -162,6 +169,22 @@ public class ParserTest {
 
         File tempFolder = new File(tempFolderName);
         if (!tempFolder.delete())
+            fail();
+    }
+
+    @Test
+    public void isJavaProgram() {
+        if (!Parser.isJavaProgram("java -jar programName.jar"))
+            fail();
+        if (Parser.isJavaProgram("steam.exe"))
+            fail();
+    }
+
+    @Test
+    public void isExeProgram() {
+        if (Parser.isExeProgram("java -jar programName.jar"))
+            fail();
+        if (!Parser.isExeProgram("steam.exe"))
             fail();
     }
 }

--- a/src/test/java/parser/ParserTest.java
+++ b/src/test/java/parser/ParserTest.java
@@ -50,7 +50,8 @@ public class ParserTest {
         }
         //if (player == null) fail();
 
-        if (!player.toString().equals("Kserkses Aleksander Dobrowolski fajny_program.exe")) fail();
+        if (!player.toString().equals("Kserkses Aleksander Dobrowolski fajny_program.exe"))
+            fail();
     }
 
     @Test
@@ -74,7 +75,7 @@ public class ParserTest {
             fail();
         }
 
-        if (!player.getFullLunchCommand().matches("java -jar [A-Z]:\\\\.*\\\\\\d{6}\\\\.*.jar"))
+        if (!player.getFullLunchCommand().matches("java -jar \"[A-Z]:\\\\.*\\\\\\d{6}\\\\.*.jar\""))
             fail();
     }
 
@@ -126,7 +127,7 @@ public class ParserTest {
             fail();
         }
 
-        if (!player.getFullLunchCommand().matches("[A-Z]:\\\\.*\\\\\\d{6}\\\\.*.exe"))
+        if (!player.getFullLunchCommand().matches("\"[A-Z]:\\\\.*\\\\\\d{6}\\\\.*.exe\""))
             fail();
     }
 


### PR DESCRIPTION
`Parser` now sets `Player` `fullLunchCommand` to correct command with full absolute path.
It works **only** for **java** and all **.exe** files.

In case there is already path in info.txt file it's not changed in any way.

Behavior of setting `fullLuncCommand` is now **removed** form `FileManager` as it is done by `Parser`.